### PR TITLE
[BE] PR 리뷰 리마인더 봇 구현

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -1,15 +1,11 @@
 name: PR Review Reminder
 
 on:
-    # schedule:
+  schedule:
     # 한국 시간 12시에 실행 (UTC 기준 03시)
-    # - cron: '0 3 * * *'
-    # 한국 시간 18시에 실행 (UTC 기준 09시)
-    # - cron: '0 9 * * *'
-
-    # PR 이벤트에 대해 동작하도록 설정
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    - cron: '0 3 * * *'
+    # 한국 시간 21시에 실행 (UTC 기준 09시)
+    - cron: '0 12 * * *'
 
   workflow_dispatch:
 

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -1,0 +1,247 @@
+name: PR Review Reminder
+
+on:
+    # schedule:
+    # 한국 시간 12시에 실행 (UTC 기준 03시)
+    # - cron: '0 3 * * *'
+    # 한국 시간 18시에 실행 (UTC 기준 09시)
+    # - cron: '0 9 * * *'
+
+    # PR 이벤트에 대해 동작하도록 설정
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+  workflow_dispatch:
+
+jobs:
+  review-reminder:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Get open PRs and requested reviewers
+        id: get-prs
+        run: |
+          reviewer_map='[
+            {"github": "Miaash", "discord": "<@938048520374603817>"},
+            {"github": "viaunixue", "discord": "<@386917108455309316>"},
+            {"github": "swwho96", "discord": "<@816298263614455839>"},
+            {"github": "PracticeKJY", "discord": "<@460816530007916554>"}
+          ]'
+
+          prs=$(gh api graphql -F owner=$OWNER -F repo=$REPO -f query='
+            query($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequests(states: OPEN, first: 100) {
+                  edges {
+                    node {
+                      number
+                      title
+                      url
+                      reviews(last: 100) {
+                        nodes {
+                          state
+                          author {
+                            login
+                          }
+                        }
+                      }
+                      reviewRequests(first: 100) {
+                        nodes {
+                          requestedReviewer {
+                            ... on User {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' --jq '.data.repository.pullRequests.edges | map({number: .node.number, title: .node.title, url: .node.url, reviews: .node.reviews.nodes, reviewRequests: .node.reviewRequests.nodes})')
+          
+          prs_without_completed_reviews="[]"
+          ready_to_merge_prs="[]"
+          while read -r pr; do
+            echo "Debug: PR data"
+            echo "$pr" | jq '.'
+
+            pr_number=$(echo "$pr" | jq -r '.number')
+            pr_url=$(echo "$pr" | jq -r '.url')
+            pr_title=$(echo "$pr" | jq -r '.title')
+            
+            reviews=$(echo "$pr" | jq -r '.reviews // [] | .[] | select(.state == "APPROVED") | .author.login')
+            review_requests=$(echo "$pr" | jq -r '.reviewRequests // [] | .[].requestedReviewer.login')
+
+            all_approved=true
+            incomplete_reviewers=()
+            for reviewer in $review_requests; do
+              if [[ ! " $reviews " =~ " $reviewer " ]]; then
+                all_approved=false
+                incomplete_reviewers+=("$reviewer")
+              fi
+            done
+
+            if [ "$all_approved" = false ]; then
+              pr=$(echo "$pr" | jq --argjson reviewers "$(printf '%s\n' "${incomplete_reviewers[@]}" | jq -R . | jq -s .)" '. + {incompleteReviewers: $reviewers}')
+              prs_without_completed_reviews=$(echo "$prs_without_completed_reviews" | jq --argjson pr "$pr" '. += [$pr]')
+            else
+              ready_to_merge_prs=$(echo "$ready_to_merge_prs" | jq --arg number "$pr_number" --arg title "$pr_title" --arg url "$pr_url" '. += [{"number": $number, "title": $title, "url": $url}]')
+            fi
+          done < <(echo "$prs" | jq -c '.[]')
+          
+          echo "$prs_without_completed_reviews" > prs.json
+          echo "$prs_without_completed_reviews" > prs_to_review.json
+          echo "$ready_to_merge_prs" > prs_ready_to_merge.json
+          
+          if [ "$(echo "$prs_without_completed_reviews" | jq length)" -gt 0 ]; then
+            echo "has_prs_to_review=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_prs_to_review=false" >> $GITHUB_OUTPUT
+          fi
+          
+          if [ "$(echo "$ready_to_merge_prs" | jq length)" -gt 0 ]; then
+            echo "has_prs_ready_to_merge=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_prs_ready_to_merge=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Prepare merge ready notification
+        if: steps.get-prs.outputs.has_prs_ready_to_merge == 'true'
+        id: prepare-merge-notification
+        run: |
+          ready_prs=$(cat prs_ready_to_merge.json)
+          pr_list=""
+          mentions=""
+          while read -r pr; do
+            pr_number=$(echo "$pr" | jq -r '.number')
+            pr_title=$(echo "$pr" | jq -r '.title')
+            pr_url=$(echo "$pr" | jq -r '.url')
+            pr_author=$(gh api repos/$OWNER/$REPO/pulls/$pr_number --jq '.user.login')
+            
+            # GitHub 사용자를 Discord 사용자로 매핑
+            discord_user=$(echo "$reviewer_map" | jq --arg user "$pr_author" -r '.[] | select(.github == $user) | .discord')
+            if [ -n "$discord_user" ]; then
+              mentions+="$discord_user "
+            fi
+            
+            pr_list+="- [PR #$pr_number: \"$pr_title\"]($pr_url) (작성자: $pr_author)\n"
+          done < <(echo "$ready_prs" | jq -c '.[]')
+          
+          current_time=$(date --utc +%Y-%m-%dT%H:%M:%SZ)
+          merge_notification=$(jq -n \
+            --arg title "병합 준비 완료!" \
+            --arg description "$mentions\n\n다음 PR들이 모든 리뷰를 통과하여 병합 준비가 완료되었습니다:\n$pr_list" \
+            --arg thumbnail "https://github.com/user-attachments/assets/5bbf4cfb-67a9-402b-969e-8fb142c37f0f" \
+            --arg author_name "PR MERGE BOT" \
+            --arg author_icon "https://avatars.githubusercontent.com/u/9919?s=200&v=4" \
+            --arg footer_text "NEONADEULI" \
+            --arg footer_icon "https://github.com/user-attachments/assets/5bbf4cfb-67a9-402b-969e-8fb142c37f0f" \
+            --arg timestamp "$current_time" \
+            '{
+              "embeds": [{
+                "title": $title,
+                "description": $description,
+                "color": 3066993,
+                "thumbnail": {"url": $thumbnail},
+                "author": {
+                  "name": $author_name,
+                  "icon_url": $author_icon
+                },
+                "footer": {
+                  "text": $footer_text,
+                  "icon_url": $footer_icon
+                },
+                "timestamp": $timestamp
+              }]
+            }')
+          echo "$merge_notification" > merge_notification.json
+          echo "has_merge_notification=true" >> $GITHUB_OUTPUT
+
+      - name: Map GitHub users to Discord users and notify
+        id: map-github-users
+        run: |
+          prs=$(cat prs.json)
+          embed_fields="[]"
+          reviewers_processed=()
+          while read -r pr; do
+            pr_number=$(echo "$pr" | jq -r '.number')
+            pr_title=$(echo "$pr" | jq -r '.title')
+            pr_url=$(echo "$pr" | jq -r '.url')
+            incomplete_reviewers=$(echo "$pr" | jq -r '.incompleteReviewers[]')
+            for reviewer in $incomplete_reviewers; do
+              if [[ ! " ${reviewers_processed[@]} " =~ " ${reviewer} " ]]; then
+                reviewers_processed+=("$reviewer")
+                discord_user=$(echo "$reviewer_map" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .discord')
+                if [ -n "$discord_user" ]; then
+                  github_user=$(echo "$reviewer_map" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .github')
+                  pr_list=""
+                  while read -r pr_item; do
+                    pr_num=$(echo "$pr_item" | jq -r '.number')
+                    pr_title=$(echo "$pr_item" | jq -r '.title')
+                    pr_url=$(echo "$pr_item" | jq -r '.url')
+                    pr_list+="- [PR #$pr_num: \"$pr_title\"]($pr_url)\n"
+                  done < <(echo "$prs" | jq -c --arg user "$reviewer" '.[] | select(.incompleteReviewers[] == $user)')
+                  pr_count=$(echo "$prs" | jq --arg user "$reviewer" '[.[] | select(.incompleteReviewers[] == $user)] | length')
+                  fire_count=$(printf ' 🔥%.0s' $(seq 1 $pr_count))
+                  embed_fields=$(echo "$embed_fields" | jq --arg name "$github_user $fire_count ($pr_count건)" --arg value "$discord_user\n$pr_list" '. += [{"name": $name, "value": ($value | gsub("\\\\n"; "\n")), "inline": false}]')
+                fi
+              fi
+            done
+          done < <(echo "$prs" | jq -c '.[]')
+
+          if [ "$(echo "$embed_fields" | jq length)" -eq 0 ]; then
+            echo "No reviewers to notify."
+            echo "has_notifications=false" >> $GITHUB_OUTPUT
+          else
+            current_time=$(date --utc +%Y-%m-%dT%H:%M:%SZ)
+            embed=$(jq -n \
+              --arg title "리뷰를 기다리고 있어요!!" \
+              --arg description "[리뷰하러 가기](https://github.com/$OWNER/$REPO/pulls)" \
+              --argjson fields "$embed_fields" \
+              --arg thumbnail "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRidSZL4BdECVb3sL0ZQ2jZSYIWNDQTiTcJJQ&usqp=CAU" \
+              --arg author_name "PR REMINDER BOT" \
+              --arg author_icon "https://avatars.githubusercontent.com/u/9919?s=200&v=4" \
+              --arg footer_text "NEONADEULI" \
+              --arg footer_icon "https://github.com/user-attachments/assets/5bbf4cfb-67a9-402b-969e-8fb142c37f0f" \
+              --arg timestamp "$current_time" \
+              '{
+                "embeds": [{
+                  "title": $title,
+                  "description": $description,
+                  "color": 15258703,
+                  "fields": $fields,
+                  "thumbnail": {"url": $thumbnail},
+                  "author": {
+                    "name": $author_name,
+                    "icon_url": $author_icon
+                  },
+                  "footer": {
+                    "text": $footer_text,
+                    "icon_url": $footer_icon
+                  },
+                  "timestamp": $timestamp
+                }]
+              }')
+            echo "$embed" > embed.json
+            echo "has_notifications=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
+        if: steps.map-github-users.outputs.has_notifications == 'true'
+        run: |
+          if [ "${{ steps.map-github-users.outputs.has_notifications }}" == "true" ]; then
+            curl -H "Content-Type: application/json" -d @embed.json ${{ secrets.DISCORD_WEBHOOK_URL }}
+          fi
+          if [ "${{ steps.prepare-merge-notification.outputs.has_merge_notification }}" == "true" ]; then
+            curl -H "Content-Type: application/json" -d @merge_notification.json ${{ secrets.DISCORD_WEBHOOK_URL }}
+          fi

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -13,14 +13,20 @@ on:
 
   workflow_dispatch:
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  OWNER: ${{ github.repository_owner }}
+  REPO: ${{ github.event.repository.name }}
+  REVIEWER_MAP: '[
+    {"github": "Miaash", "discord": "<@938048520374603817>"}, 
+    {"github": "viaunixue", "discord": "<@386917108455309316>"},
+    {"github": "swwho96", "discord": "<@816298263614455839>"},
+    {"github": "PracticeKJY", "discord": "<@460816530007916554>"}
+   ]'
+
 jobs:
   review-reminder:
     runs-on: ubuntu-latest
-
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      OWNER: ${{ github.repository_owner }}
-      REPO: ${{ github.event.repository.name }}
 
     steps:
       - name: Check out the code
@@ -29,13 +35,6 @@ jobs:
       - name: Get open PRs and requested reviewers
         id: get-prs
         run: |
-          reviewer_map='[
-            {"github": "Miaash", "discord": "<@938048520374603817>"},
-            {"github": "viaunixue", "discord": "<@386917108455309316>"},
-            {"github": "swwho96", "discord": "<@816298263614455839>"},
-            {"github": "PracticeKJY", "discord": "<@460816530007916554>"}
-          ]'
-
           prs=$(gh api graphql -F owner=$OWNER -F repo=$REPO -f query='
             query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -129,7 +128,7 @@ jobs:
             pr_author=$(gh api repos/$OWNER/$REPO/pulls/$pr_number --jq '.user.login')
             
             # GitHub 사용자를 Discord 사용자로 매핑
-            discord_user=$(echo "$reviewer_map" | jq --arg user "$pr_author" -r '.[] | select(.github == $user) | .discord')
+            discord_user=$(echo "$REVIEWER_MAP" | jq --arg user "$pr_author" -r '.[] | select(.github == $user) | .discord')
             if [ -n "$discord_user" ]; then
               mentions+="$discord_user "
             fi
@@ -181,9 +180,9 @@ jobs:
             for reviewer in $incomplete_reviewers; do
               if [[ ! " ${reviewers_processed[@]} " =~ " ${reviewer} " ]]; then
                 reviewers_processed+=("$reviewer")
-                discord_user=$(echo "$reviewer_map" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .discord')
+                discord_user=$(echo "$REVIEWER_MAP" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .discord')
                 if [ -n "$discord_user" ]; then
-                  github_user=$(echo "$reviewer_map" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .github')
+                  github_user=$(echo "$REVIEWER_MAP" | jq --arg user "$reviewer" -r '.[] | select(.github == $user) | .github')
                   pr_list=""
                   while read -r pr_item; do
                     pr_num=$(echo "$pr_item" | jq -r '.number')


### PR DESCRIPTION
## 💡 작업 내용

- [x] Github Action WorkFlow 설정
- [x] GitHub 사용자와 Discord 사용자 매핑 구현
- [x] 리뷰 대기 중인 PR에 대한 Discord 알림 생성
- [x] 병합 준비된 PR에 대한 Discord 알림 생성
- [x] Discord webhook을 통한 알림 전송 구현

## 🫨 고민한 부분

- 리뷰 상태에 따른 PR 분류 로직

## 📌 중점적으로 볼 부분

- 리뷰 상태 확인 및 PR 분류 로직
- Discord 알림 메시지 생성 부분

## 🎯 테스트 결과

- 로컬 환경에서 워크플로우 실행 결과 정상 작동 확인
- PR 생성 및 업데이트 시 워크플로우 트리거 확인
- Discord 알림 메시지 정상 전송 확인

## 🎇 동작 화면

> 디스 코드 리뷰 요청 메시지 성공
 
![image](https://github.com/user-attachments/assets/94933503-0c28-4ac3-9434-28770b156e87)

> 모두 승인했을 때 병합 메시지 

## 📗 참고 자료 (선택)

## 🙏리뷰 요구사항(선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

## 💫 기타사항

close #19 